### PR TITLE
Bug #133

### DIFF
--- a/btfxwss/connection.py
+++ b/btfxwss/connection.py
@@ -407,15 +407,15 @@ class WebSocketConnection(Thread):
         :param data:
         :param ts:
         """
-        info_message = {'20051': 'Stop/Restart websocket server '
+        info_message = {20051: 'Stop/Restart websocket server '
                                  '(please try to reconnect)',
-                        '20060': 'Refreshing data from the trading engine; '
+                        20060: 'Refreshing data from the trading engine; '
                                  'please pause any acivity.',
-                        '20061': 'Done refreshing data from the trading engine.'
+                        20061: 'Done refreshing data from the trading engine.'
                                  ' Re-subscription advised.'}
 
-        codes = {'20051': self.reconnect, '20060': self._pause,
-                 '20061': self._unpause}
+        codes = {20051: self.reconnect, 20060: self._pause,
+                 20061: self._unpause}
 
         if 'version' in data:
             self.log.info("API version: %i", data['version'])


### PR DESCRIPTION
This should fix bug #133 with info messages having the wrong type. 

As described in the [Bitfinex Docs](https://docs.bitfinex.com/v2/docs/ws-general#section-info-messages) the codes are always integers.
