### PR TITLE
ISSUE RESOLVED  [SSL: CERTIFICATE_VERIFY_FAILED]

### DIFF
--- a/btfxwss/connection.py
+++ b/btfxwss/connection.py
@@ -53,7 +53,7 @@ class WebSocketConnection(Thread):
         # Connection Settings
         self.socket = None
         self.url = url if url else 'wss://api.bitfinex.com/ws/2'
-        self.sslopt = sslopt if sslopt else {}
+        self.sslopt = {"cert_reqs": ssl.CERT_NONE}
         
         # Proxy Settings
         self.http_proxy_host = http_proxy_host


### PR DESCRIPTION
People facing this error 
btfxwss.connection:Connection Error - [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:777)

can use this code.